### PR TITLE
fix: typo stracktrace -> stacktrace

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ require("chainsaw").assertLog()
 require("chainsaw").messageLog()
 
 -- prints the stacktrace of the current call
-require("chainsaw").stracktraceLog()
+require("chainsaw").stacktraceLog()
 
 -- Minimal log statement, with an emoji for differentiation. Intended for
 -- control flow inspection, i.e. to quickly glance whether a condition was

--- a/doc/chainsaw.txt
+++ b/doc/chainsaw.txt
@@ -93,7 +93,7 @@ LIST OF COMMANDS ~
     require("chainsaw").messageLog()
     
     -- prints the stacktrace of the current call
-    require("chainsaw").stracktraceLog()
+    require("chainsaw").stacktraceLog()
     
     -- Minimal log statement, with an emoji for differentiation. Intended for
     -- control flow inspection, i.e. to quickly glance whether a condition was

--- a/lua/chainsaw/init.lua
+++ b/lua/chainsaw/init.lua
@@ -53,8 +53,8 @@ function M.objectLog()
 	u.appendLines(logLines, { config.marker, varname, varname })
 end
 
-function M.stracktraceLog()
-	local logLines = u.getTemplateStr("stracktraceLog", config.logStatements)
+function M.stacktraceLog()
+	local logLines = u.getTemplateStr("stacktraceLog", config.logStatements)
 	if not logLines then return end
 	u.appendLines(logLines, { config.marker })
 end

--- a/lua/chainsaw/log-statements-data.lua
+++ b/lua/chainsaw/log-statements-data.lua
@@ -29,15 +29,15 @@ return {
 		javascript = 'console.log("%s %s:", JSON.stringify(%s))',
 		ruby = 'puts "%s %s: #{%s.inspect}"',
 	},
-	stracktraceLog = { -- %s -> marker
+	stacktraceLog = { -- %s -> marker
 		lua = 'print(debug.traceback("%s"))', -- `debug.traceback` already prepends "stacktrace"
 		nvim_lua = 'vim.notify(debug.traceback("%s"))',
 		sh = 'print "%s stacktrack: $funcfiletrace $funcstack"', -- defaulting to zsh here, since it's more common than bash
 		zsh = 'print "%s stacktrack: $funcfiletrace $funcstack"',
 		bash = "print '%s stacktrace: ' ; caller 0",
-		javascript = 'console.log("%s stracktrace: ", new Error().stack.replaceAll("\n", " "));', -- not all JS engines support console.trace()
-		typescript = 'console.trace("%s strackstrace: ");',
-		typescriptreact = 'console.trace("%s strackstrace: ");',
+		javascript = 'console.log("%s stacktrace: ", new Error().stack.replaceAll("\n", " "));', -- not all JS engines support console.trace()
+		typescript = 'console.trace("%s stacktrace: ");',
+		typescriptreact = 'console.trace("%s stacktrace: ");',
 	},
 	beepLog = { -- %s -> 1st: marker, 2nd: beepEmoji
 		nvim_lua = 'vim.notify("%s beep %s")',


### PR DESCRIPTION
for a better diff view, try `git diff --word-diff`

## Checklist
- [x ] Used only camelCase variable names.
- [x ] If functionality is added or modified, also made respective changes to the
  README.md (the `.txt` file is auto-generated and does not need to be modified).
- [ x] Used conventional commits keywords.
